### PR TITLE
[chore][pkg/stanza/fileconsumer] Emit logs in batches

### DIFF
--- a/.chloggen/elasticsearchexporter_ecs-translate-k8s-names.yaml
+++ b/.chloggen/elasticsearchexporter_ecs-translate-k8s-names.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Translate `k8s.*.name` resource attributes in ECS mode
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36233]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Translate `k8s.job.name`, `k8s.cronjob.name`, `k8s.statefulset.name`, `k8s.replicaset.name`, `k8s.daemonset.name`, `k8s.container.name` to `kubernetes.*.name`. Translate `k8s.cluster.name` to `orchestrator.cluster.name`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/fix_group_container_permissions.yaml
+++ b/.chloggen/fix_group_container_permissions.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: container
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Set non root group permissions for container image
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35179]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/otlpjson-connector-invalid-otlp.yaml
+++ b/.chloggen/otlpjson-connector-invalid-otlp.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: connector/otlpjson
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Throw error on invalid otlp payload. 
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35738, 35739]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/refactor-callback-token.yaml
+++ b/.chloggen/refactor-callback-token.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed signature of `emit.Callback` function in `pkg/stanza/fileconsumer/emit` package by introducing `emit.Token` struct that encapsulates the token's body and attributes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36260]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/refactor-callback-token.yaml
+++ b/.chloggen/refactor-callback-token.yaml
@@ -7,7 +7,7 @@ change_type: breaking
 component: pkg/stanza
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Changed signature of `emit.Callback` function in `pkg/stanza/fileconsumer/emit` package by introducing `emit.Token` struct that encapsulates the token's body and attributes.
+note: Change signature of `emit.Callback` function in `pkg/stanza/fileconsumer/emit` package to emit multiple tokens. Each token's body and attributes are encapsulated in a new `emit.Token` struct.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [36260]

--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -4,7 +4,8 @@ RUN apk --update add ca-certificates
 FROM scratch
 
 ARG USER_UID=10001
-USER ${USER_UID}
+ARG USER_GID=10001
+USER ${USER_UID}:${USER_GID}
 
 COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY otelcontribcol /

--- a/cmd/telemetrygen/Dockerfile
+++ b/cmd/telemetrygen/Dockerfile
@@ -4,7 +4,8 @@ RUN apk --update add ca-certificates
 FROM scratch
 
 ARG USER_UID=10001
-USER ${USER_UID}
+ARG USER_GID=10001
+USER ${USER_UID}:${USER_GID}
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/connector/otlpjsonconnector/factory.go
+++ b/connector/otlpjsonconnector/factory.go
@@ -5,6 +5,7 @@ package otlpjsonconnector // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
+	"regexp"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector"
@@ -12,6 +13,10 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector/internal/metadata"
 )
+
+var logRegex = regexp.MustCompile(`^\{\s*"resourceLogs"\s*:\s*\[`)
+var metricRegex = regexp.MustCompile(`^\{\s*"resourceMetrics"\s*:\s*\[`)
+var traceRegex = regexp.MustCompile(`^\{\s*"resourceSpans"\s*:\s*\[`)
 
 // NewFactory returns a ConnectorFactory.
 func NewFactory() connector.Factory {

--- a/connector/otlpjsonconnector/logs.go
+++ b/connector/otlpjsonconnector/logs.go
@@ -50,16 +50,29 @@ func (c *connectorLogs) ConsumeLogs(ctx context.Context, pl plog.Logs) error {
 			for k := 0; k < logRecord.LogRecords().Len(); k++ {
 				lRecord := logRecord.LogRecords().At(k)
 				token := lRecord.Body()
-				var l plog.Logs
-				l, err := logsUnmarshaler.UnmarshalLogs([]byte(token.AsString()))
-				if err != nil {
-					c.logger.Error("could not extract logs from otlp json", zap.Error(err))
+
+				// Check if the "resourceLogs" key exists in the JSON data
+				value := token.AsString()
+				switch {
+				case logRegex.MatchString(value):
+					var l plog.Logs
+					l, err := logsUnmarshaler.UnmarshalLogs([]byte(value))
+					if err != nil {
+						c.logger.Error("could not extract logs from otlp json", zap.Error(err))
+						continue
+					}
+					err = c.logsConsumer.ConsumeLogs(ctx, l)
+					if err != nil {
+						c.logger.Error("could not consume logs from otlp json", zap.Error(err))
+					}
+				case metricRegex.MatchString(value), traceRegex.MatchString(value):
+					// If it's a metric or trace payload, simply continue
 					continue
+				default:
+					// If no regex matches, log the invalid payload
+					c.logger.Error("Invalid otlp payload")
 				}
-				err = c.logsConsumer.ConsumeLogs(ctx, l)
-				if err != nil {
-					c.logger.Error("could not consume logs from otlp json", zap.Error(err))
-				}
+
 			}
 		}
 	}

--- a/connector/otlpjsonconnector/metrics.go
+++ b/connector/otlpjsonconnector/metrics.go
@@ -51,16 +51,28 @@ func (c *connectorMetrics) ConsumeLogs(ctx context.Context, pl plog.Logs) error 
 			for k := 0; k < logRecord.LogRecords().Len(); k++ {
 				lRecord := logRecord.LogRecords().At(k)
 				token := lRecord.Body()
-				var m pmetric.Metrics
-				m, err := metricsUnmarshaler.UnmarshalMetrics([]byte(token.AsString()))
-				if err != nil {
-					c.logger.Error("could extract metrics from otlp json", zap.Error(err))
+
+				value := token.AsString()
+				switch {
+				case metricRegex.MatchString(value):
+					var m pmetric.Metrics
+					m, err := metricsUnmarshaler.UnmarshalMetrics([]byte(value))
+					if err != nil {
+						c.logger.Error("could not extract metrics from otlp json", zap.Error(err))
+						continue
+					}
+					err = c.metricsConsumer.ConsumeMetrics(ctx, m)
+					if err != nil {
+						c.logger.Error("could not consume metrics from otlp json", zap.Error(err))
+					}
+				case logRegex.MatchString(value), traceRegex.MatchString(value):
+					// If it's a log or trace payload, simply continue
 					continue
+				default:
+					// If no regex matches, log the invalid payload
+					c.logger.Error("Invalid otlp payload")
 				}
-				err = c.metricsConsumer.ConsumeMetrics(ctx, m)
-				if err != nil {
-					c.logger.Error("could not consume metrics from otlp json", zap.Error(err))
-				}
+
 			}
 		}
 	}

--- a/connector/otlpjsonconnector/traces.go
+++ b/connector/otlpjsonconnector/traces.go
@@ -51,15 +51,26 @@ func (c *connectorTraces) ConsumeLogs(ctx context.Context, pl plog.Logs) error {
 			for k := 0; k < logRecord.LogRecords().Len(); k++ {
 				lRecord := logRecord.LogRecords().At(k)
 				token := lRecord.Body()
-				var t ptrace.Traces
-				t, err := tracesUnmarshaler.UnmarshalTraces([]byte(token.AsString()))
-				if err != nil {
-					c.logger.Error("could extract traces from otlp json", zap.Error(err))
+
+				value := token.AsString()
+				switch {
+				case traceRegex.MatchString(value):
+					var t ptrace.Traces
+					t, err := tracesUnmarshaler.UnmarshalTraces([]byte(value))
+					if err != nil {
+						c.logger.Error("could not extract traces from otlp json", zap.Error(err))
+						continue
+					}
+					err = c.tracesConsumer.ConsumeTraces(ctx, t)
+					if err != nil {
+						c.logger.Error("could not consume traces from otlp json", zap.Error(err))
+					}
+				case metricRegex.MatchString(value), logRegex.MatchString(value):
+					// If it's a metric or log payload, continue to the next iteration
 					continue
-				}
-				err = c.tracesConsumer.ConsumeTraces(ctx, t)
-				if err != nil {
-					c.logger.Error("could not consume traces from otlp json", zap.Error(err))
+				default:
+					// If no regex matches, log the invalid payload
+					c.logger.Error("Invalid otlp payload")
 				}
 			}
 		}

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -268,31 +268,38 @@ If the target ECS field name is specified as an empty string (""), the converter
 
 When "Preserved" is true, the attribute will be preserved in the payload and duplicated as mapped to its ECS equivalent.
 
-| Semantic Convention Name | ECS Name | Preserve |
-|--------------------------|----------|----------|
-| cloud.platform           | cloud.service.name | false |
-| container.image.tags     | container.image.tag | false |
-| deployment.environment   | service.environment | false |
-| host.arch                | host.architecture | false |
-| host.name                | host.hostname | true |
-| k8s.deployment.name      | kubernetes.deployment.name | false |
-| k8s.namespace.name       | kubernetes.namespace | false |
-| k8s.node.name            | kubernetes.node.name | false |
-| k8s.pod.name             | kubernetes.pod.name | false |
-| k8s.pod.uid              | kubernetes.pod.uid | false |
-| os.description           | host.os.full | false |
-| os.name                  | host.os.name | false |
-| os.type                  | host.os.platform | false |
-| os.version               | host.os.version | false |
-| process.executable.path  | process.executable | false |
-| process.runtime.name     | service.runtime.name | false |
-| process.runtime.version  | service.runtime.version | false |
-| service.instance.id      | service.node.name | false |
-| telemetry.distro.name    | "" | false |
-| telemetry.distro.version | "" | false |
-| telemetry.sdk.language   | "" | false |
-| telemetry.sdk.name       | "" | false |
-| telemetry.sdk.version    | "" | false |
+| Semantic Convention Name | ECS Name                    | Preserve |
+|--------------------------|-----------------------------|----------|
+| cloud.platform           | cloud.service.name          | false    |
+| container.image.tags     | container.image.tag         | false    |
+| deployment.environment   | service.environment         | false    |
+| host.arch                | host.architecture           | false    |
+| host.name                | host.hostname               | true     |
+| k8s.cluster.name         | orchestrator.cluster.name   | false    |
+| k8s.container.name       | kubernetes.container.name   | false    |
+| k8s.cronjob.name         | kubernetes.cronjob.name     | false    |
+| k8s.daemonset.name       | kubernetes.daemonset.name   | false    |
+| k8s.deployment.name      | kubernetes.deployment.name  | false    |
+| k8s.job.name             | kubernetes.job.name         | false    |
+| k8s.namespace.name       | kubernetes.namespace        | false    |
+| k8s.node.name            | kubernetes.node.name        | false    |
+| k8s.pod.name             | kubernetes.pod.name         | false    |
+| k8s.pod.uid              | kubernetes.pod.uid          | false    |
+| k8s.replicaset.name      | kubernetes.replicaset.name  | false    |
+| k8s.statefulset.name     | kubernetes.statefulset.name | false    |
+| os.description           | host.os.full                | false    |
+| os.name                  | host.os.name                | false    |
+| os.type                  | host.os.platform            | false    |
+| os.version               | host.os.version             | false    |
+| process.executable.path  | process.executable          | false    |
+| process.runtime.name     | service.runtime.name        | false    |
+| process.runtime.version  | service.runtime.version     | false    |
+| service.instance.id      | service.node.name           | false    |
+| telemetry.distro.name    | ""                          | false    |
+| telemetry.distro.version | ""                          | false    |
+| telemetry.sdk.language   | ""                          | false    |
+| telemetry.sdk.name       | ""                          | false    |
+| telemetry.sdk.version    | ""                          | false    |
 
 ### Compound Mapping
 

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -505,7 +505,6 @@ func TestExporterLogs(t *testing.T) {
 			)
 			tc.body.CopyTo(logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body())
 			mustSendLogs(t, exporter, logs)
-			rec.WaitItems(1)
 
 			expected := []itemRequest{
 				{
@@ -514,7 +513,7 @@ func TestExporterLogs(t *testing.T) {
 				},
 			}
 
-			assertItemsEqual(t, expected, rec.Items(), false)
+			assertRecordedItems(t, expected, rec, false)
 		}
 
 	})
@@ -889,8 +888,6 @@ func TestExporterMetrics(t *testing.T) {
 
 		mustSendMetrics(t, exporter, metrics)
 
-		rec.WaitItems(8)
-
 		expected := []itemRequest{
 			{
 				Action:   []byte(`{"create":{"_index":"metrics-generic-bar"}}`),
@@ -926,7 +923,7 @@ func TestExporterMetrics(t *testing.T) {
 			},
 		}
 
-		assertItemsEqual(t, expected, rec.Items(), false)
+		assertRecordedItems(t, expected, rec, false)
 	})
 
 	t.Run("publish histogram", func(t *testing.T) {
@@ -959,8 +956,6 @@ func TestExporterMetrics(t *testing.T) {
 
 		mustSendMetrics(t, exporter, metrics)
 
-		rec.WaitItems(2)
-
 		expected := []itemRequest{
 			{
 				Action:   []byte(`{"create":{"_index":"metrics-generic-default"}}`),
@@ -972,7 +967,7 @@ func TestExporterMetrics(t *testing.T) {
 			},
 		}
 
-		assertItemsEqual(t, expected, rec.Items(), false)
+		assertRecordedItems(t, expected, rec, false)
 	})
 
 	t.Run("publish exponential histogram", func(t *testing.T) {
@@ -1005,8 +1000,6 @@ func TestExporterMetrics(t *testing.T) {
 
 		mustSendMetrics(t, exporter, metrics)
 
-		rec.WaitItems(1)
-
 		expected := []itemRequest{
 			{
 				Action:   []byte(`{"create":{"_index":"metrics-generic-default"}}`),
@@ -1014,7 +1007,7 @@ func TestExporterMetrics(t *testing.T) {
 			},
 		}
 
-		assertItemsEqual(t, expected, rec.Items(), false)
+		assertRecordedItems(t, expected, rec, false)
 	})
 
 	t.Run("publish histogram cumulative temporality", func(t *testing.T) {
@@ -1113,8 +1106,6 @@ func TestExporterMetrics(t *testing.T) {
 		err := exporter.ConsumeMetrics(context.Background(), metrics)
 		assert.NoError(t, err)
 
-		rec.WaitItems(2)
-
 		expected := []itemRequest{
 			{
 				Action:   []byte(`{"create":{"_index":"metrics-generic-default"}}`),
@@ -1126,7 +1117,7 @@ func TestExporterMetrics(t *testing.T) {
 			},
 		}
 
-		assertItemsEqual(t, expected, rec.Items(), false)
+		assertRecordedItems(t, expected, rec, false)
 	})
 
 	t.Run("otel mode", func(t *testing.T) {
@@ -1176,8 +1167,6 @@ func TestExporterMetrics(t *testing.T) {
 
 		mustSendMetrics(t, exporter, metrics)
 
-		rec.WaitItems(2)
-
 		expected := []itemRequest{
 			{
 				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.metric.foo":"histogram"}}}`),
@@ -1197,7 +1186,7 @@ func TestExporterMetrics(t *testing.T) {
 			},
 		}
 
-		assertItemsEqual(t, expected, rec.Items(), false)
+		assertRecordedItems(t, expected, rec, false)
 	})
 
 	t.Run("otel mode attribute array value", func(t *testing.T) {
@@ -1259,7 +1248,6 @@ func TestExporterMetrics(t *testing.T) {
 
 		mustSendMetrics(t, exporter, metrics)
 
-		rec.WaitItems(1)
 		expected := []itemRequest{
 			{
 				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.sum":"gauge_long","metrics.summary":"summary"}}}`),
@@ -1267,7 +1255,7 @@ func TestExporterMetrics(t *testing.T) {
 			},
 		}
 
-		assertItemsEqual(t, expected, rec.Items(), false)
+		assertRecordedItems(t, expected, rec, false)
 	})
 
 	t.Run("otel mode aggregate_metric_double hint", func(t *testing.T) {
@@ -1310,7 +1298,6 @@ func TestExporterMetrics(t *testing.T) {
 
 		mustSendMetrics(t, exporter, metrics)
 
-		rec.WaitItems(1)
 		expected := []itemRequest{
 			{
 				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.histogram.summary":"summary"}}}`),
@@ -1322,7 +1309,7 @@ func TestExporterMetrics(t *testing.T) {
 			},
 		}
 
-		assertItemsEqual(t, expected, rec.Items(), false)
+		assertRecordedItems(t, expected, rec, false)
 	})
 
 	t.Run("otel mode metric name conflict", func(t *testing.T) {
@@ -1354,7 +1341,6 @@ func TestExporterMetrics(t *testing.T) {
 
 		mustSendMetrics(t, exporter, metrics)
 
-		rec.WaitItems(1)
 		expected := []itemRequest{
 			{
 				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.foo.bar":"gauge_long","metrics.foo":"gauge_long","metrics.foo.bar.baz":"gauge_long"}}}`),
@@ -1362,7 +1348,7 @@ func TestExporterMetrics(t *testing.T) {
 			},
 		}
 
-		assertItemsEqual(t, expected, rec.Items(), false)
+		assertRecordedItems(t, expected, rec, false)
 	})
 
 	t.Run("otel mode attribute key prefix conflict", func(t *testing.T) {
@@ -1422,8 +1408,6 @@ func TestExporterMetrics(t *testing.T) {
 
 		mustSendMetrics(t, exporter, metrics)
 
-		rec.WaitItems(2)
-
 		expected := []itemRequest{
 			{
 				Action:   []byte(`{"create":{"_index":"metrics-generic-default"}}`),
@@ -1435,7 +1419,7 @@ func TestExporterMetrics(t *testing.T) {
 			},
 		}
 
-		assertItemsEqual(t, expected, rec.Items(), false)
+		assertRecordedItems(t, expected, rec, false)
 	})
 }
 
@@ -1644,8 +1628,6 @@ func TestExporterTraces(t *testing.T) {
 
 		mustSendTraces(t, exporter, traces)
 
-		rec.WaitItems(2)
-
 		expected := []itemRequest{
 			{
 				Action:   []byte(`{"create":{"_index":"traces-generic.otel-default"}}`),
@@ -1657,7 +1639,7 @@ func TestExporterTraces(t *testing.T) {
 			},
 		}
 
-		assertItemsEqual(t, expected, rec.Items(), false)
+		assertRecordedItems(t, expected, rec, false)
 	})
 
 	t.Run("otel mode attribute array value", func(t *testing.T) {

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -57,6 +57,13 @@ var resourceAttrsConversionMap = map[string]string{
 	semconv.AttributeK8SNodeName:            "kubernetes.node.name",
 	semconv.AttributeK8SPodName:             "kubernetes.pod.name",
 	semconv.AttributeK8SPodUID:              "kubernetes.pod.uid",
+	semconv.AttributeK8SJobName:             "kubernetes.job.name",
+	semconv.AttributeK8SCronJobName:         "kubernetes.cronjob.name",
+	semconv.AttributeK8SStatefulSetName:     "kubernetes.statefulset.name",
+	semconv.AttributeK8SReplicaSetName:      "kubernetes.replicaset.name",
+	semconv.AttributeK8SDaemonSetName:       "kubernetes.daemonset.name",
+	semconv.AttributeK8SContainerName:       "kubernetes.container.name",
+	semconv.AttributeK8SClusterName:         "orchestrator.cluster.name",
 }
 
 // resourceAttrsToPreserve contains conventions that should be preserved in ECS mode.

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -381,6 +381,13 @@ func TestEncodeLogECSMode(t *testing.T) {
 		"k8s.pod.name":                         "opentelemetry-pod-autoconf",
 		"k8s.pod.uid":                          "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff",
 		"k8s.deployment.name":                  "coredns",
+		semconv.AttributeK8SJobName:            "job.name",
+		semconv.AttributeK8SCronJobName:        "cronjob.name",
+		semconv.AttributeK8SStatefulSetName:    "statefulset.name",
+		semconv.AttributeK8SReplicaSetName:     "replicaset.name",
+		semconv.AttributeK8SDaemonSetName:      "daemonset.name",
+		semconv.AttributeK8SContainerName:      "container.name",
+		semconv.AttributeK8SClusterName:        "cluster.name",
 	})
 	require.NoError(t, err)
 
@@ -444,7 +451,14 @@ func TestEncodeLogECSMode(t *testing.T) {
 		"kubernetes.node.name":       "node-1",
 		"kubernetes.pod.name":        "opentelemetry-pod-autoconf",
 		"kubernetes.pod.uid":         "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff",
-		"kubernetes.deployment.name": "coredns"
+		"kubernetes.deployment.name": "coredns",
+		"kubernetes.job.name":         "job.name",
+		"kubernetes.cronjob.name":     "cronjob.name",
+		"kubernetes.statefulset.name": "statefulset.name",
+		"kubernetes.replicaset.name":  "replicaset.name",
+		"kubernetes.daemonset.name":   "daemonset.name",
+		"kubernetes.container.name":   "container.name",
+		"orchestrator.cluster.name":   "cluster.name"
 	}`, buf.String())
 }
 

--- a/extension/storage/dbstorage/extension_test.go
+++ b/extension/storage/dbstorage/extension_test.go
@@ -6,6 +6,8 @@ package dbstorage
 import (
 	"context"
 	"fmt"
+	"os"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -22,10 +24,18 @@ import (
 )
 
 func TestExtensionIntegrityWithSqlite(t *testing.T) {
+	if runtime.GOOS == "windows" && os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping test on Windows GH runners: test requires Docker to be running Linux containers")
+	}
+
 	testExtensionIntegrity(t, newSqliteTestExtension(t))
 }
 
 func TestExtensionIntegrityWithPostgres(t *testing.T) {
+	if runtime.GOOS == "windows" && os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping test on Windows GH runners: test requires Docker to be running Linux containers")
+	}
+
 	testExtensionIntegrity(t, newPostgresTestExtension(t))
 }
 

--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -188,9 +188,12 @@ func BenchmarkFileInput(b *testing.B) {
 			cfg.PollInterval = time.Microsecond
 
 			doneChan := make(chan bool, len(files))
-			callback := func(_ context.Context, token emit.Token) error {
-				if len(token.Body) == 0 {
-					doneChan <- true
+			callback := func(_ context.Context, tokens []emit.Token) error {
+				for _, token := range tokens {
+					if len(token.Body) == 0 {
+						doneChan <- true
+						break
+					}
 				}
 				return nil
 			}

--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/filetest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -187,8 +188,8 @@ func BenchmarkFileInput(b *testing.B) {
 			cfg.PollInterval = time.Microsecond
 
 			doneChan := make(chan bool, len(files))
-			callback := func(_ context.Context, token []byte, _ map[string]any) error {
-				if len(token) == 0 {
+			callback := func(_ context.Context, token emit.Token) error {
+				if len(token.Body) == 0 {
 					doneChan <- true
 				}
 				return nil

--- a/pkg/stanza/fileconsumer/emit/emit.go
+++ b/pkg/stanza/fileconsumer/emit/emit.go
@@ -7,4 +7,16 @@ import (
 	"context"
 )
 
-type Callback func(ctx context.Context, token []byte, attrs map[string]any) error
+type Callback func(ctx context.Context, token Token) error
+
+type Token struct {
+	Body       []byte
+	Attributes map[string]any
+}
+
+func NewToken(body []byte, attrs map[string]any) Token {
+	return Token{
+		Body:       body,
+		Attributes: attrs,
+	}
+}

--- a/pkg/stanza/fileconsumer/emit/emit.go
+++ b/pkg/stanza/fileconsumer/emit/emit.go
@@ -7,7 +7,7 @@ import (
 	"context"
 )
 
-type Callback func(ctx context.Context, token Token) error
+type Callback func(ctx context.Context, tokens []Token) error
 
 type Token struct {
 	Body       []byte

--- a/pkg/stanza/fileconsumer/internal/emittest/nop.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/nop.go
@@ -5,8 +5,10 @@ package emittest // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"context"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
 )
 
-func Nop(_ context.Context, _ []byte, _ map[string]any) error {
+func Nop(_ context.Context, _ emit.Token) error {
 	return nil
 }

--- a/pkg/stanza/fileconsumer/internal/emittest/nop.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/nop.go
@@ -9,6 +9,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
 )
 
-func Nop(_ context.Context, _ emit.Token) error {
+func Nop(_ context.Context, _ []emit.Token) error {
 	return nil
 }

--- a/pkg/stanza/fileconsumer/internal/emittest/nop_test.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/nop_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
 )
 
 func TestNop(t *testing.T) {
-	require.NoError(t, Nop(context.Background(), nil, nil))
+	require.NoError(t, Nop(context.Background(), emit.Token{}))
 }

--- a/pkg/stanza/fileconsumer/internal/emittest/nop_test.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/nop_test.go
@@ -13,5 +13,5 @@ import (
 )
 
 func TestNop(t *testing.T) {
-	require.NoError(t, Nop(context.Background(), emit.Token{}))
+	require.NoError(t, Nop(context.Background(), []emit.Token{}))
 }

--- a/pkg/stanza/fileconsumer/internal/emittest/sink.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/sink.go
@@ -57,13 +57,15 @@ func NewSink(opts ...SinkOpt) *Sink {
 	return &Sink{
 		emitChan: emitChan,
 		timeout:  cfg.timeout,
-		Callback: func(ctx context.Context, token emit.Token) error {
-			copied := make([]byte, len(token.Body))
-			copy(copied, token.Body)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case emitChan <- &Call{copied, token.Attributes}:
+		Callback: func(ctx context.Context, tokens []emit.Token) error {
+			for _, token := range tokens {
+				copied := make([]byte, len(token.Body))
+				copy(copied, token.Body)
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case emitChan <- &Call{copied, token.Attributes}:
+				}
 			}
 			return nil
 		},

--- a/pkg/stanza/fileconsumer/internal/emittest/sink.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/sink.go
@@ -57,13 +57,13 @@ func NewSink(opts ...SinkOpt) *Sink {
 	return &Sink{
 		emitChan: emitChan,
 		timeout:  cfg.timeout,
-		Callback: func(ctx context.Context, token []byte, attrs map[string]any) error {
-			copied := make([]byte, len(token))
-			copy(copied, token)
+		Callback: func(ctx context.Context, token emit.Token) error {
+			copied := make([]byte, len(token.Body))
+			copy(copied, token.Body)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case emitChan <- &Call{copied, attrs}:
+			case emitChan <- &Call{copied, token.Attributes}:
 			}
 			return nil
 		},

--- a/pkg/stanza/fileconsumer/internal/emittest/sink_test.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/sink_test.go
@@ -204,7 +204,7 @@ func sinkTest(t *testing.T, opts ...SinkOpt) (*Sink, []*Call) {
 	}
 	go func() {
 		for _, c := range testCalls {
-			assert.NoError(t, s.Callback(context.Background(), emit.NewToken(c.Token, c.Attrs)))
+			assert.NoError(t, s.Callback(context.Background(), []emit.Token{emit.NewToken(c.Token, c.Attrs)}))
 		}
 	}()
 	return s, testCalls

--- a/pkg/stanza/fileconsumer/internal/emittest/sink_test.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/sink_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
 )
 
 func TestNextToken(t *testing.T) {
@@ -202,7 +204,7 @@ func sinkTest(t *testing.T, opts ...SinkOpt) (*Sink, []*Call) {
 	}
 	go func() {
 		for _, c := range testCalls {
-			assert.NoError(t, s.Callback(context.Background(), c.Token, c.Attrs))
+			assert.NoError(t, s.Callback(context.Background(), emit.NewToken(c.Token, c.Attrs)))
 		}
 	}()
 	return s, testCalls

--- a/pkg/stanza/fileconsumer/internal/reader/factory.go
+++ b/pkg/stanza/fileconsumer/internal/reader/factory.go
@@ -24,8 +24,9 @@ import (
 )
 
 const (
-	DefaultMaxLogSize  = 1024 * 1024
-	DefaultFlushPeriod = 500 * time.Millisecond
+	DefaultMaxLogSize   = 1024 * 1024
+	DefaultFlushPeriod  = 500 * time.Millisecond
+	DefaultMaxBatchSize = 100
 )
 
 type Factory struct {
@@ -78,6 +79,7 @@ func (f *Factory) NewReaderFromMetadata(file *os.File, m *Metadata) (r *Reader, 
 		includeFileRecordNum: f.IncludeFileRecordNumber,
 		compression:          f.Compression,
 		acquireFSLock:        f.AcquireFSLock,
+		maxBatchSize:         DefaultMaxBatchSize,
 	}
 	r.set.Logger = r.set.Logger.With(zap.String("path", r.fileName))
 

--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -209,7 +209,7 @@ func (r *Reader) readContents(ctx context.Context) {
 			r.FileAttributes[attrs.LogFileRecordNumber] = r.RecordNum
 		}
 
-		err = r.emitFunc(ctx, token, r.FileAttributes)
+		err = r.emitFunc(ctx, emit.NewToken(token, r.FileAttributes))
 		if err != nil {
 			r.set.Logger.Error("failed to process token", zap.Error(err))
 		}

--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -52,6 +52,7 @@ type Reader struct {
 	includeFileRecordNum   bool
 	compression            string
 	acquireFSLock          bool
+	maxBatchSize           int
 }
 
 // ReadToEnd will read until the end of the file
@@ -179,6 +180,8 @@ func (r *Reader) readContents(ctx context.Context) {
 	// Create the scanner to read the contents of the file.
 	s := scanner.New(r, r.maxLogSize, r.initialBufferSize, r.Offset, r.contentSplitFunc)
 
+	tokens := make([]emit.Token, 0, r.maxBatchSize)
+
 	// Iterate over the contents of the file.
 	for {
 		select {
@@ -194,7 +197,7 @@ func (r *Reader) readContents(ctx context.Context) {
 			} else if r.deleteAtEOF {
 				r.delete()
 			}
-			return
+			break
 		}
 
 		token, err := r.decoder.Decode(s.Bytes())
@@ -209,13 +212,49 @@ func (r *Reader) readContents(ctx context.Context) {
 			r.FileAttributes[attrs.LogFileRecordNumber] = r.RecordNum
 		}
 
-		err = r.emitFunc(ctx, emit.NewToken(token, r.FileAttributes))
-		if err != nil {
-			r.set.Logger.Error("failed to process token", zap.Error(err))
-		}
+		tokens = append(tokens, emit.NewToken(copyBody(token), copyAttributes(r.FileAttributes)))
 
+		if r.maxBatchSize > 0 && len(tokens) >= r.maxBatchSize {
+			for _, t := range tokens {
+				err := r.emitFunc(ctx, t)
+				if err != nil {
+					r.set.Logger.Error("failed to process token", zap.Error(err))
+				}
+			}
+			tokens = tokens[:0]
+			r.Offset = s.Pos()
+		}
+	}
+
+	if len(tokens) > 0 {
+		for _, t := range tokens {
+			err := r.emitFunc(ctx, t)
+			if err != nil {
+				r.set.Logger.Error("failed to process token", zap.Error(err))
+			}
+		}
 		r.Offset = s.Pos()
 	}
+}
+
+func copyBody(body []byte) []byte {
+	if body == nil {
+		return nil
+	}
+	copied := make([]byte, len(body))
+	copy(copied, body)
+	return copied
+}
+
+func copyAttributes(attrs map[string]any) map[string]any {
+	if attrs == nil {
+		return nil
+	}
+	copied := make(map[string]any, len(attrs))
+	for k, v := range attrs {
+		copied[k] = v
+	}
+	return copied
 }
 
 // Delete will close and delete the file

--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -215,11 +215,9 @@ func (r *Reader) readContents(ctx context.Context) {
 		tokens = append(tokens, emit.NewToken(copyBody(token), copyAttributes(r.FileAttributes)))
 
 		if r.maxBatchSize > 0 && len(tokens) >= r.maxBatchSize {
-			for _, t := range tokens {
-				err := r.emitFunc(ctx, t)
-				if err != nil {
-					r.set.Logger.Error("failed to process token", zap.Error(err))
-				}
+			err := r.emitFunc(ctx, tokens)
+			if err != nil {
+				r.set.Logger.Error("failed to process tokens", zap.Error(err))
 			}
 			tokens = tokens[:0]
 			r.Offset = s.Pos()
@@ -227,11 +225,9 @@ func (r *Reader) readContents(ctx context.Context) {
 	}
 
 	if len(tokens) > 0 {
-		for _, t := range tokens {
-			err := r.emitFunc(ctx, t)
-			if err != nil {
-				r.set.Logger.Error("failed to process token", zap.Error(err))
-			}
+		err := r.emitFunc(ctx, tokens)
+		if err != nil {
+			r.set.Logger.Error("failed to process tokens", zap.Error(err))
 		}
 		r.Offset = s.Pos()
 	}

--- a/pkg/stanza/operator/helper/emitter.go
+++ b/pkg/stanza/operator/helper/emitter.go
@@ -94,10 +94,19 @@ func (e *LogEmitter) Stop() error {
 	return nil
 }
 
-// Process will emit an entry to the output channel
+// Process emits an entry to the consumerFunc
 func (e *LogEmitter) Process(ctx context.Context, ent *entry.Entry) error {
 	if oldBatch := e.appendEntry(ent); len(oldBatch) > 0 {
 		e.consumerFunc(ctx, oldBatch)
+	}
+
+	return nil
+}
+
+// ProcessBatch emits the entries to the consumerFunc
+func (e *LogEmitter) ProcessBatch(ctx context.Context, entries []entry.Entry) error {
+	for _, entry := range entries {
+		e.Process(ctx, &entry)
 	}
 
 	return nil

--- a/pkg/stanza/operator/helper/input.go
+++ b/pkg/stanza/operator/helper/input.go
@@ -90,3 +90,12 @@ func (i *InputOperator) Process(_ context.Context, _ *entry.Entry) error {
 		"Ensure that operator is not configured to receive logs from other operators",
 	)
 }
+
+// ProcessBatch will always return an error if called.
+func (i *InputOperator) ProcessBatch(_ context.Context, _ []entry.Entry) error {
+	i.Logger().Error("Operator received a batch of entries, but can not process")
+	return errors.NewError(
+		"Operator can not process logs.",
+		"Ensure that operator is not configured to receive logs from other operators",
+	)
+}

--- a/pkg/stanza/operator/input/file/config.go
+++ b/pkg/stanza/operator/input/file/config.go
@@ -60,7 +60,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		toBody:        toBody,
 	}
 
-	input.fileConsumer, err = c.Config.Build(set, input.emit)
+	input.fileConsumer, err = c.Config.Build(set, input.emitBatch)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/file/input.go
+++ b/pkg/stanza/operator/input/file/input.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
@@ -36,17 +37,17 @@ func (i *Input) Stop() error {
 	return i.fileConsumer.Stop()
 }
 
-func (i *Input) emit(ctx context.Context, token []byte, attrs map[string]any) error {
-	if len(token) == 0 {
+func (i *Input) emit(ctx context.Context, token emit.Token) error {
+	if len(token.Body) == 0 {
 		return nil
 	}
 
-	ent, err := i.NewEntry(i.toBody(token))
+	ent, err := i.NewEntry(i.toBody(token.Body))
 	if err != nil {
 		return fmt.Errorf("create entry: %w", err)
 	}
 
-	for k, v := range attrs {
+	for k, v := range token.Attributes {
 		if err := ent.Set(entry.NewAttributeField(k), v); err != nil {
 			i.Logger().Error("set attribute", zap.Error(err))
 		}

--- a/pkg/stanza/operator/operator.go
+++ b/pkg/stanza/operator/operator.go
@@ -38,6 +38,8 @@ type Operator interface {
 	CanProcess() bool
 	// Process will process an entry from an operator.
 	Process(context.Context, *entry.Entry) error
+	// Process processes a batch of entries from an operator.
+	ProcessBatch(context.Context, []entry.Entry) error
 	// Logger returns the operator's logger
 	Logger() *zap.Logger
 }

--- a/receiver/otlpjsonfilereceiver/file.go
+++ b/receiver/otlpjsonfilereceiver/file.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver/internal/metadata"
 )
 
@@ -82,10 +83,10 @@ func createLogsReceiver(_ context.Context, settings receiver.Settings, configura
 	if cfg.ReplayFile {
 		opts = append(opts, fileconsumer.WithNoTracking())
 	}
-	input, err := cfg.Config.Build(settings.TelemetrySettings, func(ctx context.Context, token []byte, _ map[string]any) error {
+	input, err := cfg.Config.Build(settings.TelemetrySettings, func(ctx context.Context, token emit.Token) error {
 		ctx = obsrecv.StartLogsOp(ctx)
 		var l plog.Logs
-		l, err = logsUnmarshaler.UnmarshalLogs(token)
+		l, err = logsUnmarshaler.UnmarshalLogs(token.Body)
 		if err != nil {
 			obsrecv.EndLogsOp(ctx, metadata.Type.String(), 0, err)
 		} else {
@@ -119,10 +120,10 @@ func createMetricsReceiver(_ context.Context, settings receiver.Settings, config
 	if cfg.ReplayFile {
 		opts = append(opts, fileconsumer.WithNoTracking())
 	}
-	input, err := cfg.Config.Build(settings.TelemetrySettings, func(ctx context.Context, token []byte, _ map[string]any) error {
+	input, err := cfg.Config.Build(settings.TelemetrySettings, func(ctx context.Context, token emit.Token) error {
 		ctx = obsrecv.StartMetricsOp(ctx)
 		var m pmetric.Metrics
-		m, err = metricsUnmarshaler.UnmarshalMetrics(token)
+		m, err = metricsUnmarshaler.UnmarshalMetrics(token.Body)
 		if err != nil {
 			obsrecv.EndMetricsOp(ctx, metadata.Type.String(), 0, err)
 		} else {
@@ -155,10 +156,10 @@ func createTracesReceiver(_ context.Context, settings receiver.Settings, configu
 	if cfg.ReplayFile {
 		opts = append(opts, fileconsumer.WithNoTracking())
 	}
-	input, err := cfg.Config.Build(settings.TelemetrySettings, func(ctx context.Context, token []byte, _ map[string]any) error {
+	input, err := cfg.Config.Build(settings.TelemetrySettings, func(ctx context.Context, token emit.Token) error {
 		ctx = obsrecv.StartTracesOp(ctx)
 		var t ptrace.Traces
-		t, err = tracesUnmarshaler.UnmarshalTraces(token)
+		t, err = tracesUnmarshaler.UnmarshalTraces(token.Body)
 		if err != nil {
 			obsrecv.EndTracesOp(ctx, metadata.Type.String(), 0, err)
 		} else {
@@ -183,8 +184,8 @@ func createProfilesReceiver(_ context.Context, settings receiver.Settings, confi
 	if cfg.ReplayFile {
 		opts = append(opts, fileconsumer.WithNoTracking())
 	}
-	input, err := cfg.Config.Build(settings.TelemetrySettings, func(ctx context.Context, token []byte, _ map[string]any) error {
-		p, _ := profilesUnmarshaler.UnmarshalProfiles(token)
+	input, err := cfg.Config.Build(settings.TelemetrySettings, func(ctx context.Context, token emit.Token) error {
+		p, _ := profilesUnmarshaler.UnmarshalProfiles(token.Body)
 		if p.ResourceProfiles().Len() != 0 {
 			_ = profiles.ConsumeProfiles(ctx, p)
 		}


### PR DESCRIPTION
#### Description

Modifies the File consumer to emit logs in batches as opposed to sending each log individually through the Stanza pipeline and on to the Log Emitter.

This was achieved via the following incremental changes, with the goal of making code reviews easier (multiple smaller changesets):

- https://github.com/andrzej-stencel/opentelemetry-collector-contrib/commit/e1ebd3e334971738ff3a3f3619680b1d50e7a7ee collect scanned tokens into batches in `Reader::ReadToEnd` method in File consumer, but still call `emit` function for each token individually
- https://github.com/andrzej-stencel/opentelemetry-collector-contrib/commit/5ff590ec9d4a2af1d9feaf8445b0de418130fe32 change `emit.Callback` function signature to accept a slice of tokens and emit tokens in batches from the `Reader`. At this point, the batches are still split into individual tokens inside the `emit` function, because the Stanza operators can only process one entry at a time.
- https://github.com/andrzej-stencel/opentelemetry-collector-contrib/commit/d302d5cf0f21f1a7fdb86252c0d838d6160debdb add `ProcessBatch` method to Stanza operators and use it in the `emit` function. At this point, the batch of tokens is translated to a batch of entries and passed to Log Emitter as a whole. The batch is still split in the Log Emitter, which calls `consumeFunc` for each entry in a loop.
- https://github.com/andrzej-stencel/opentelemetry-collector-contrib/commit/5492cb477a151cc6fa247946ca29fd46d53c953c do not split batches in Log Emitter, call `consumeFunc` on the whole batch of entries

Note that this is currently a draft, requesting initial feedback. I haven't yet implemented the `ProcessBatch` method for all Stanza operators, as I'd like to first get feedback its definition. Specifically, should the function accept a `[]entry.Entry` or `[]*entry.Entry`?

#### Link to tracking issue

- Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35455

#### Testing

No changes in tests. The goal is for the functionality to not change and for performance to not decrease.

#### Documentation

These are internal changes, no user documentation needs changing.